### PR TITLE
update senders-api query params and json parser

### DIFF
--- a/src/main/java/com/dyn/client/v3/messaging/features/SendersApi.java
+++ b/src/main/java/com/dyn/client/v3/messaging/features/SendersApi.java
@@ -54,15 +54,14 @@ public interface SendersApi {
 	@Path("/senders/details")
 	@SelectJson("data")
 	@Consumes(APPLICATION_JSON)
-	Map<String, Object> getDetails(
-			@FormParam("emailaddress") String emailAddress);
+	Map<String, Object> getDetails(@QueryParam("emailaddress") String emailAddress);
 
 	@Named("GetSenderStatus")
 	@GET
 	@Path("/senders/status")
 	@SelectJson("data")
 	@Consumes(APPLICATION_JSON)
-	Map<String, Object> getStatus(@FormParam("emailaddress") String emailAddress);
+	Map<String, Object> getStatus(@QueryParam("emailaddress") String emailAddress);
 
 	@Named("CreateOrUpdateSender")
 	@POST
@@ -70,7 +69,7 @@ public interface SendersApi {
 	@SelectJson("data")
 	@Produces(APPLICATION_FORM_URLENCODED)
 	@Consumes(APPLICATION_JSON)
-	List<Map<String, Object>> createOrUpdate(
+    Map<String, Object> createOrUpdate(
 			@FormParam("emailaddress") String emailAddress,
 			@FormParam("seeding") String seeding);
 


### PR DESCRIPTION
Currently the SendersApi.createOrUpdate API json response for the 'data' key/value is a JsonObject value. e.g..
`{"response":{"status":200,"message":"OK","data":{}}}`
However SendersApi.createOrUpdate expects 'data' key/value to instead be a JsonArray. This results in a json parse exception: `java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 50 path $.response.data`

Also getDetails and getStatus is not generating the endpoint param correctly due to using @FormParam instead of @QueryParam
